### PR TITLE
improves field type suggestion

### DIFF
--- a/src/sqlfileimporter.cpp
+++ b/src/sqlfileimporter.cpp
@@ -21,21 +21,18 @@
 
 static bool isdigitstr(const char *str, size_t length)
 {
-    for (size_t i = 0; i < length; ++i) {
-        if (!isdigit(*str++))
-            return false;
-    }
-    return true;
+    bool isOk = false;
+    QString::fromLocal8Bit(str, length).toInt(&isOk);
+
+    return isOk;
 }
 
 static bool isrealstr(const char *str, size_t length)
 {
-    for (size_t i = 0; i < length; ++i) {
-        char ch = *str++;
-        if (!isdigit(ch) && ch != '.')
-            return false;
-    }
-    return true;
+    bool isOk = false;
+    QString::fromLocal8Bit(str, length).toDouble(&isOk);
+
+    return isOk;
 }
 
 SqlFileImporter::SqlFileImporter(QSqlDatabase *database, QObject *parent) :

--- a/src/sqlfileimporter.cpp
+++ b/src/sqlfileimporter.cpp
@@ -22,7 +22,7 @@
 static bool isdigitstr(const char *str, size_t length)
 {
     bool isOk = false;
-    QString::fromLocal8Bit(str, length).toInt(&isOk);
+    QString::fromUtf8(str, length).toInt(&isOk);
 
     return isOk;
 }
@@ -30,7 +30,7 @@ static bool isdigitstr(const char *str, size_t length)
 static bool isrealstr(const char *str, size_t length)
 {
     bool isOk = false;
-    QString::fromLocal8Bit(str, length).toDouble(&isOk);
+    QString::fromUtf8(str, length).toDouble(&isOk);
 
     return isOk;
 }


### PR DESCRIPTION
The previous version of Hyokai can not correctly suggest field type of columns
which contain negative integers or real values represented by exponent notation (e.g. -1, 12e3, etc.). 
They were suggested as string type. 
This change fixes the above issue.
