### PR TITLE
Hyokai seems to be freezed when try to import some CSV/TSV files

### DIFF
--- a/src/sqlservice.cpp
+++ b/src/sqlservice.cpp
@@ -65,6 +65,7 @@ QString SqlService::suggestFieldName(const QString &fieldName, const QList<Schem
     bool nameChanged = false;
     int i = 1;
     do {
+        nameChanged = false;
         foreach (SchemaField onefield, currentSchema) {
             if (onefield.name() == newname) {
                 newname = QString("%1_%2").arg(basename, QString::number(i++));


### PR DESCRIPTION
Hyokai falls into infinite loop (`foreach` in SqlService::suggestFieldName) when try to import some csv/tsv file. (example: https://db.tt/mzJhIZ4o)
This change fixes the problem.
